### PR TITLE
Provide basic README

### DIFF
--- a/.github/ISSUE_TEMPLATE/event-request.md
+++ b/.github/ISSUE_TEMPLATE/event-request.md
@@ -1,6 +1,6 @@
 ---
 name: Event request
-about: Request a new EventGrid event
+about: Request a new Azure event
 title: New event request
 labels: ''
 assignees: ''

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Azure emits a variety of events to Azure Event Grid which allows you to extend a
 ## How can you help?
 
 - **Propose new event suggestions** by opening a new issue
-- **Vote for an event** that you'd like to be supported by giving a :+1: on the issue
+- **Vote for the events** you'd like to see supported by giving a :+1: on the issues
 - **Discuss events** to provide valuable information to the Microsoft service teams
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Azure Event Wishlist
+
+Azure emits a variety of events to Azure Event Grid which allows you to extend and react to what's going on in your apps & infrastructure, but not everything is there yet.
+
+**Azure Event Wishlist** is a dashboard that gathers all events that would be great to have in Azure!
+
+## How can you help?
+
+- **Propose new event suggestions** by opening a new issue
+- **Vote for an event** that you'd like to be supported by giving a :+1: on the issue
+
+## Examples
+
+Here are examples of how powerful Azure events can be:
+
+- [Monitoring Key Vault with Azure Event Grid](https://docs.microsoft.com/en-us/azure/key-vault/event-grid-overview) and automatically renew certificates that are about to expire.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Event Wishlist
 
-Azure emits a variety of events to Azure Event Grid which allows you to extend and react to what's going on in your apps & infrastructure, but not everything is there yet.
+Azure services emit a variety of events to Azure Event Grid enabling you to extend and react to what's going on in your applications and infrastructure. Although, not all the events are there yet.
 
 **Azure Event Wishlist** is a dashboard that gathers all events that would be great to have in Azure!
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Azure emits a variety of events to Azure Event Grid which allows you to extend a
 
 - **Propose new event suggestions** by opening a new issue
 - **Vote for an event** that you'd like to be supported by giving a :+1: on the issue
+- **Discuss events** to provide valuable information to the Microsoft service teams
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Azure services emit a variety of events to Azure Event Grid enabling you to exte
 
 ## Examples
 
-Here are examples of how powerful Azure events can be:
+Here are example(s) of how powerful Azure events can be:
 
 - [Monitoring Key Vault with Azure Event Grid](https://docs.microsoft.com/en-us/azure/key-vault/event-grid-overview) and automatically renew certificates that are about to expire.


### PR DESCRIPTION
Provide basic README and explicitly call them Azure events so that people think in the broad scope of Azure and not just Event Grid.

This might also reduce the burden on Event Grid team and focus on the ecosystem, but it's just a suggestion.